### PR TITLE
[fix] German translation syntax error

### DIFF
--- a/audiodecoder.2sf/resources/language/resource.language.de_de/strings.po
+++ b/audiodecoder.2sf/resources/language/resource.language.de_de/strings.po
@@ -86,7 +86,7 @@ msgstr "{0:d} s"
 
 msgctxt "#30015"
 msgid "Resampling mode"
-msgid "Resampling-Modus"
+msgstr "Resampling-Modus"
 
 msgctxt "#30016"
 msgid "Used resampling quality about processing."


### PR DESCRIPTION
This fixes syntax error where `msgid` should be `msgstr`

Fixes this issue:
https://github.com/xbmc/audiodecoder.2sf/issues/23