### PR TITLE
[Matrix|N*] depends update, year increase and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ------------------
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.org/xbmc/audiodecoder.2sf.svg?branch=Matrix)](https://travis-ci.org/xbmc/audiodecoder.2sf/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.2sf?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=3&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.2sf/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.2sf/branches/)
 <!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.2sf?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-2sf?branch=Matrix) -->

--- a/audiodecoder.2sf/addon.xml.in
+++ b/audiodecoder.2sf/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.2sf"
-  version="3.0.1"
+  version="3.0.2"
   name="2SF Audio Decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: audiodecoder.2sf
 Source: https://github.com/xbmc/audiodecoder.2sf
 
 Files: *
-Copyright: 2005-2020 Team Kodi
+Copyright: 2005-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/lib/kodi-psflib-note.txt
+++ b/lib/kodi-psflib-note.txt
@@ -1,4 +1,2 @@
-psflib source from https://g.losno.co/chris/psflib
-Sync to 591f2a3b31 (25 May 2020)
-
-Old source https://github.com/kode54/psflib (38b1419 (28 Feb 2020))
+psflib source from https://github.com/kode54/psflib
+Sync to 77dfb4a (17 March 2021)

--- a/lib/kodi-vio2sf-note.txt
+++ b/lib/kodi-vio2sf-note.txt
@@ -1,4 +1,6 @@
-vio2sf source from https://g.losno.co/chris/vio2sf
+vio2sf source from https://git.lopez-snowhill.net/chris/vio2sf
 Sync to 1d68801f5f (2 May 2019)
 
-Old source https://bitbucket.org/kode54/vio2sf (e0501e3 (12 Dec 2017))
+Old source:
+- https://bitbucket.org/kode54/vio2sf (e0501e3 (12 Dec 2017))
+- https://g.losno.co/chris/vio2sf (1d68801f5f (2 May 2019))

--- a/lib/psflib/psf2fs.c
+++ b/lib/psflib/psf2fs.c
@@ -414,7 +414,7 @@ static int virtual_read(struct PSF2FS *fs, struct DIR_ENTRY *entry, int offset, 
       destlen = block_usize;
       // attempt decompress
       r = uncompress((unsigned char *) fs->cacheblock.uncompressed_data, &destlen, (const unsigned char *) entry->source->reserved_data + block_zofs, block_zsize);
-      if(r != Z_OK || destlen != block_usize) {
+      if(r != Z_OK || destlen != (unsigned long)block_usize) {
 //        char s[999];
 //        sprintf(s,"zdata=%02X %02X %02X blockz=%d blocku=%d destlenout=%d", zdata[0], zdata[1], zdata[2], block_zsize, block_usize, destlen);
 //        errormessageadd(fs, s);

--- a/src/2SFCodec.cpp
+++ b/src/2SFCodec.cpp
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2014-2020 Arne Morten Kvarving
- *  Copyright (C) 2016-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2014-2021 Arne Morten Kvarving
+ *  Copyright (C) 2016-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/2SFCodec.h
+++ b/src/2SFCodec.h
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2014-2020 Arne Morten Kvarving
- *  Copyright (C) 2016-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2014-2021 Arne Morten Kvarving
+ *  Copyright (C) 2016-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.

--- a/src/CircularBuffer.h
+++ b/src/CircularBuffer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2019-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2019-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.


### PR DESCRIPTION
This update:
- psflib to latest version
- correct vio2sf to new url (old no more present)
- set copyright year to 2021
- remove the status badge about Travis CI
  - The build script stais currently in, maybe usable for something else or they allow again a bit more by travis.com

Performed compile and run test on Linux with C++14, C++17 and C++20.
Runtime tests was OK.