### PR TITLE
[Nexus] initial relase change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 ------------------
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.2sf?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=3&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.2sf/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.2sf/branches/)
-<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.2sf?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-2sf?branch=Matrix) -->
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audiodecoder.2sf?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=3&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audiodecoder.2sf/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudiodecoder.2sf/branches/)
+<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.2sf?branch=Nexus&svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-2sf?branch=Nexus) -->
 
 # audiodecoder.2sf addon for Kodi
 

--- a/audiodecoder.2sf/addon.xml.in
+++ b/audiodecoder.2sf/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.2sf"
-  version="3.0.2"
+  version="20.0.0"
   name="2SF Audio Decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
 trigger:
   branches:
     include:
-    - Matrix
+    - Nexus
     - releases/*
   paths:
     include:


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.